### PR TITLE
Limit clean scope

### DIFF
--- a/Cyival.Build.Cli/Command/CleanCommand.cs
+++ b/Cyival.Build.Cli/Command/CleanCommand.cs
@@ -20,12 +20,59 @@ public sealed class CleanCommand : Command<CleanCommand.Settings>
 
     public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
-        var tempDirectories = Directory.GetDirectories(settings.Path, ".cybuild", SearchOption.AllDirectories);
-        var directories = tempDirectories
-            .Where(dir => !File.Exists(Path.Combine(dir, ".no_clean")))
-            .Select(dir => Path.GetFullPath(Path.Combine(dir, "..")));
+        var startPath = Path.GetFullPath(settings.Path);
 
-        foreach (var dir in directories)
+        // Find a manifest in startPath or its parent (one level up)
+        static bool HasManifest(string dir)
+            => File.Exists(Path.Combine(dir, "Cybuild.toml")) || File.Exists(Path.Combine(dir, "build.toml"));
+
+        string? manifestDir = null;
+
+        if (Directory.Exists(startPath) && HasManifest(startPath))
+            manifestDir = startPath;
+        else
+        {
+            var parent = Path.GetDirectoryName(startPath);
+            if (!string.IsNullOrEmpty(parent) && HasManifest(parent))
+                manifestDir = parent;
+        }
+
+        if (manifestDir is null)
+        {
+            AnsiConsole.MarkupLine("[yellow]No manifest found in the specified path or its parent. Aborting clean.[/]");
+            return 1;
+        }
+
+        // Collect .cybuild directories up to depth 2 relative to manifestDir
+        var toDeleteParents = new HashSet<string>();
+
+        // Depth 0: manifestDir itself
+        var cand = Path.Combine(manifestDir, ".cybuild");
+        if (Directory.Exists(cand) && !File.Exists(Path.Combine(cand, ".no_clean")))
+            toDeleteParents.Add(Path.GetFullPath(manifestDir));
+
+        // Depth 1 and 2: search immediate children and their immediate children
+        foreach (var child in Directory.GetDirectories(manifestDir))
+        {
+            var childDot = Path.Combine(child, ".cybuild");
+            if (Directory.Exists(childDot) && !File.Exists(Path.Combine(childDot, ".no_clean")))
+                toDeleteParents.Add(Path.GetFullPath(child));
+
+            foreach (var grand in Directory.GetDirectories(child))
+            {
+                var grandDot = Path.Combine(grand, ".cybuild");
+                if (Directory.Exists(grandDot) && !File.Exists(Path.Combine(grandDot, ".no_clean")))
+                    toDeleteParents.Add(Path.GetFullPath(grand));
+            }
+        }
+
+        if (!toDeleteParents.Any())
+        {
+            AnsiConsole.MarkupLine("[yellow]No build temporary directories (.cybuild) found within project scope.[/]");
+            return 0;
+        }
+
+        foreach (var dir in toDeleteParents)
         {
             var confirmation = true;
 

--- a/Cyival.Build.Tests/CleanCommandTests.cs
+++ b/Cyival.Build.Tests/CleanCommandTests.cs
@@ -1,0 +1,72 @@
+using System.Threading;
+using Cyival.Build.Cli.Command;
+using Spectre.Console.Cli;
+
+namespace Cyival.Build.Tests;
+
+public class CleanCommandTests
+{
+    [Fact]
+    public void Execute_NoManifest_ShouldAbortAndNotDelete()
+    {
+        var temp = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(temp);
+
+        var proj = Path.Combine(temp, "project");
+        Directory.CreateDirectory(proj);
+        Directory.CreateDirectory(Path.Combine(proj, ".cybuild"));
+
+        var settings = new CleanCommand.Settings { Path = temp, AgreeAll = true };
+        var cmd = new CleanCommand();
+
+        var rc = cmd.Execute(default(CommandContext), settings, CancellationToken.None);
+
+        Assert.Equal(1, rc);
+        Assert.True(Directory.Exists(Path.Combine(proj, ".cybuild")));
+
+        Directory.Delete(temp, true);
+    }
+
+    [Fact]
+    public void Execute_WithManifest_DeletesUpToDepthTwoOnly()
+    {
+        var temp = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(temp);
+
+        // place manifest in root
+        File.WriteAllText(Path.Combine(temp, "build.toml"), "minimal-version = 0.1\n");
+
+        // top-level project
+        var proj1 = Path.Combine(temp, "proj1");
+        Directory.CreateDirectory(proj1);
+        Directory.CreateDirectory(Path.Combine(proj1, ".cybuild"));
+
+        // depth 2 project
+        var sub = Path.Combine(temp, "subdir");
+        Directory.CreateDirectory(sub);
+        var proj2 = Path.Combine(sub, "proj2");
+        Directory.CreateDirectory(proj2);
+        Directory.CreateDirectory(Path.Combine(proj2, ".cybuild"));
+
+        // depth 3 project (should NOT be deleted)
+        var deep = Path.Combine(temp, "deep");
+        Directory.CreateDirectory(deep);
+        var deep2 = Path.Combine(deep, "deeper");
+        Directory.CreateDirectory(deep2);
+        var proj3 = Path.Combine(deep2, "proj3");
+        Directory.CreateDirectory(proj3);
+        Directory.CreateDirectory(Path.Combine(proj3, ".cybuild"));
+
+        var settings = new CleanCommand.Settings { Path = temp, AgreeAll = true };
+        var cmd = new CleanCommand();
+
+        var rc = cmd.Execute(default(CommandContext), settings, CancellationToken.None);
+
+        Assert.Equal(0, rc);
+        Assert.False(Directory.Exists(proj1));
+        Assert.False(Directory.Exists(proj2));
+        Assert.True(Directory.Exists(proj3));
+
+        Directory.Delete(temp, true);
+    }
+}

--- a/Cyival.Build.Tests/Cyival.Build.Tests.csproj
+++ b/Cyival.Build.Tests/Cyival.Build.Tests.csproj
@@ -20,6 +20,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Cyival.Build\Cyival.Build.csproj" />
+      <ProjectReference Include="..\Cyival.Build.Cli\Cyival.Build.Cli.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #11 — limit clean to manifest project and depth 2.